### PR TITLE
ci: Add workflow to refresh the cache of the README

### DIFF
--- a/.github/workflows/clear-readme-cache.yaml
+++ b/.github/workflows/clear-readme-cache.yaml
@@ -1,0 +1,17 @@
+name: Clear README cache
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+jobs:
+  manifests:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Clear README cache
+        run: |
+          curl -fSsL https://github.com/${GITHUB_REPO}/blob/main/README.md | grep -Eo '<img src=\\"[^"]+"' | grep camo | grep -Eo 'https[^"]+' | sed 's/\\//' | xargs -I {} curl -fSsL -w "\n" -s -X PURGE {}
+        env:
+          GITHUB_REPO: ${{ github.repository }}


### PR DESCRIPTION
This should keep the Kromgo metrics up to date, though a delay may be needed for the metrics to be updated with new cluster changes.

Just something I threw together, feel free to reject this or do it better or ignore this :joy: 
